### PR TITLE
bugfix/accurics_remediation_8958513449344856 - Auto Generated Pull Request From Accurics

### DIFF
--- a/test/e2e/test_data/iac/resource_skipping/terraform/main.tf
+++ b/test/e2e/test_data/iac/resource_skipping/terraform/main.tf
@@ -33,7 +33,7 @@ resource "aws_db_instance" "PtShGgAdi2" {
   username                = "slaflheafllaflaehf"
   password                = "something"
   skip_final_snapshot     = true
-  multi_az = false
+  multi_az                = false
 }
 
 resource "aws_db_instance" "PtShGgAdi3" {
@@ -46,7 +46,7 @@ resource "aws_db_instance" "PtShGgAdi3" {
   backup_retention_period             = 30
   iam_database_authentication_enabled = false
   auto_minor_version_upgrade          = false
-  publicly_accessible                 = true
+  publicly_accessible                 = false
   username                            = "slaflheafllaflaehf"
   password                            = "something"
   skip_final_snapshot                 = true


### PR DESCRIPTION
Public Access can be disabled for AWS RDS Instances using AWS Console.
 In AWS Console - 
 1. Sign in to the AWS Console and go to the AWS RDS Console.
 2. In the RDS Dashboard, click on instances.
 3. Select the RDS instance that you want to examine and click Instance Actions button from the dashboard top menu and select See Details.
 4. Make sure Publicly Accessible flag status is not set to 'Yes' and the security group associated with the instance does not allow access to everyone, i.e. '0.0.0.0/0:'.